### PR TITLE
 use atomic instead of mutex

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"sync"
 	"time"
+	"sync/atomic"
 )
 
 // Job holds all the data related to a worker's instance.
@@ -56,7 +57,6 @@ type Pool struct {
 	worker_wg            sync.WaitGroup
 	supervisor_wg        sync.WaitGroup
 	next_job_id          uint64
-	next_job_id_mutex    sync.Mutex
 }
 
 // subworker catches any panic while running the job.
@@ -238,11 +238,7 @@ func (pool *Pool) Add(f func(...interface{}) interface{}, args ...interface{}) {
 }
 
 func (pool *Pool) getNextJobId() uint64 {
-	pool.next_job_id_mutex.Lock()
-	job_id := pool.next_job_id
-	pool.next_job_id++
-	pool.next_job_id_mutex.Unlock()
-	return job_id
+	return atomic.AddUint64(&pool.next_job_id,1)
 }
 
 // Wait blocks until all the jobs in the Pool are done.

--- a/pool.go
+++ b/pool.go
@@ -13,8 +13,8 @@ import (
 	"fmt"
 	"log"
 	"sync"
-	"time"
 	"sync/atomic"
+	"time"
 )
 
 // Job holds all the data related to a worker's instance.
@@ -238,7 +238,7 @@ func (pool *Pool) Add(f func(...interface{}) interface{}, args ...interface{}) {
 }
 
 func (pool *Pool) getNextJobId() uint64 {
-	return atomic.AddUint64(&pool.next_job_id,1)
+	return atomic.AddUint64(&pool.next_job_id, 1)
 }
 
 // Wait blocks until all the jobs in the Pool are done.


### PR DESCRIPTION
Its a good idea that rename Next_job_id to next_job_id, public is not thread safe.
But i still think atomic is better, simplify and effective,  is this proposal acceptable to you?